### PR TITLE
Fix RSS feed URL

### DIFF
--- a/partials/footer.hbs
+++ b/partials/footer.hbs
@@ -3,7 +3,7 @@
     theme by <a href="https://github.com/ktweeden">Kate Preston</a>
   </div>
   <div class="footer-container">
-    <a href="{{@blog.url/rss}}" class="social-button"><i class="icon-rss"></i></a>
+    <a href="{{@blog.url}}/rss" class="social-button"><i class="icon-rss"></i></a>
     <a class="social-button twitter hidden"><i class="icon-twitter"></i></a>
     <a class="social-button github hidden"><i class="icon-github"></i></a>
     <a class="social-button facebook hidden"><i class="icon-facebook"></i></a>


### PR DESCRIPTION
I noticed the URL for the RSS feed wasn't being generated correctly in the footer - the link would direct back to `some-website.com`, rather than `some-website.com/rss`. Turns out the /rss path needed to be outside the Handlebars expression in the footer partial, not inside.

This issue came up on a separate project, but I used your code as a model so wanted to submit a fix here as well in case you were interested.

Thanks!